### PR TITLE
Fix \textbackslash{} rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test.lg
 test.tmp
 test.xref
 test.pdf
+test.xcp

--- a/html-plain.cfg
+++ b/html-plain.cfg
@@ -1,4 +1,4 @@
-\Preamble{xhtml}  
+\Preamble{xhtml}
 
 \RequirePackage{ifthen}
 
@@ -22,7 +22,7 @@
 \renewcommand{\textbf}[1]{\HCode{<strong>}#1\HCode{</strong>}}
 \renewcommand{\emph}[1]{\HCode{<em>}#1\HCode{</em>}}
 \renewcommand{\texttt}[1]{\HCode{<code>}#1\HCode{</code>}}
-
+\renewcommand{\textbackslash}{\HCode{!!TEXTBACKSLASH!!}}
 
 \Configure{()}{\HCode{<span class="math">}}{\HCode{</span>}}
 % \Configure{footnote}{\HCode{<span>FOT1}}{\HCode{FOT2</span>}}
@@ -70,4 +70,4 @@
 
 \begin{document}
 
-\EndPreamble  
+\EndPreamble

--- a/post-process-html.py
+++ b/post-process-html.py
@@ -237,5 +237,6 @@ result = result.replace('&ffllig;', 'ffl')
 result = result.replace('&fjlig;', 'fj')
 result = result.replace('&fllig;', 'fl')
 result = result.replace('&filig;', 'fi')
+result = result.replace('!!TEXTBACKSLASH!!', '\\')
 
 print(result)

--- a/tests/special-chars-001/expected.html
+++ b/tests/special-chars-001/expected.html
@@ -1,0 +1,10 @@
+<html><head>
+<title></title>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
+<link href="test.css" rel="stylesheet" type="text/css"/>
+</head>
+<body><article>
+<p>INF\R1\211001</p>
+
+
+</article></body></html>

--- a/tests/special-chars-001/test.tex
+++ b/tests/special-chars-001/test.tex
@@ -1,0 +1,9 @@
+%\documentclass[10pt,sigplan,review]{acmart}
+\documentclass{article}
+
+\usepackage[T1]{fontenc}
+\usepackage[tt=false, type1=true]{libertine}
+
+\begin{document}
+INF\textbackslash{}R1\textbackslash{}211001
+\end{document}


### PR DESCRIPTION
The combination of libertine and fontenc packages break rendering of \textbackslash{}.
This happens for instance when using [acmart](https://github.com/borisveytsman/acmart).

This PR works around the issue, by redefining the macro in html-plain.cfg, and then replacing the placeholder during post-processing.